### PR TITLE
refactor!: complete refactor to streamline API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,10 @@ install:
 
 build: install
 	@echo -e "$(TARGET_COLOR)Running build$(NO_COLOR)"
+	@find . -type f \( -name "*.js" -o -name "*.d.ts" \) \
+		| grep -v 'node_modules' \
+		| grep -v 'cdk.out/asset' \
+		| xargs rm -f
 	@npx tsc
 
 test:

--- a/Makefile
+++ b/Makefile
@@ -15,10 +15,7 @@ install:
 
 build: install
 	@echo -e "$(TARGET_COLOR)Running build$(NO_COLOR)"
-	@find . -type f \( -name "*.js" -o -name "*.d.ts" \) \
-		| grep -v 'node_modules' \
-		| grep -v 'cdk.out/asset' \
-		| xargs rm -f
+	@find . -type f \( -name "*.js" -o -name "*.d.ts" \) ! -path "./node_modules/*" ! -path "./test/node_modules/*" -exec rm -f {} +
 	@npx tsc
 
 test:

--- a/README.md
+++ b/README.md
@@ -13,49 +13,70 @@ You can find a complete example in the [test](test) directory.
 Basic usage:
 
 ```typescript
-import { CustomResource, Event } from 'aws-cloudformation-custom-resource';
-import { Callback, Context } from 'aws-lambda';
+import {
+  Callback,
+  Context,
+  CustomResource,
+  Event,
+  Logger,
+} from 'aws-cloudformation-custom-resource';
 
 export const handler = function (
   event: Event,
   context: Context,
   callback: Callback,
 ) {
-  new CustomResource(context, callback)
-    .onCreate(createResource)
-    .onUpdate(updateResource)
-    .onDelete(deleteResource)
-    .handle(event);
+  new CustomResource(
+    event,
+    context,
+    callback,
+    createResource,
+    updateResource,
+    deleteResource,
+  );
 };
 
-function createResource(event: Event): Promise<Event> {
+function createResource(
+  resource: CustomResource,
+  logger: Logger,
+): Promise<void> {
   return new Promise(function (resolve, reject) {
+    logger.log('Hello from create');
+
     // Every custom resource requires a physical ID.
     // Either you can pass a `Name` parameter to the lambda function
     // or you can manually set the ID:
-    event.setPhysicalResourceId('some-physical-resource-id');
+    resource.setPhysicalResourceId('some-physical-resource-id');
 
     // you can return values from the Lambda function:
-    event.addResponseValue('Foo', 'bar');
+    resource.addResponseValue('Foo', 'bar');
 
     // do stuff
-    resolve(event);
+    resolve();
   });
 }
 
-function updateResource(event: Event): Promise<Event> {
+function updateResource(
+  resource: CustomResource,
+  logger: Logger,
+): Promise<void> {
+  logger.log('Hello from update');
   return new Promise(function (resolve, reject) {
-    event.addResponseValue('Foo', 'bar');
+    resource.addResponseValue('Foo', 'bar');
 
     // do stuff
-    resolve(event);
+    resolve();
   });
 }
 
-function deleteResource(event: Event): Promise<Event> {
+function deleteResource(
+  resource: CustomResource,
+  logger: Logger,
+): Promise<void> {
+  logger.log('Hello from delete');
   return new Promise(function (resolve, reject) {
     // do stuff
-    resolve(event);
+    resolve();
   });
 }
 ```
@@ -64,14 +85,25 @@ By default only errors are logged. You can change the log level or use another l
 
 ```typescript
 import {
+  Callback,
+  Context,
   CustomResource,
-  StandardLogger,
+  Event,
   LogLevel,
+  StandardLogger,
 } from 'aws-cloudformation-custom-resource';
 
 const logger = new StandardLogger(LogLevel.debug);
 
-new CustomResource(context, callback, logger);
+new CustomResource(
+  event,
+  context,
+  callback,
+  createResource,
+  updateResource,
+  deleteResource,
+  logger,
+);
 ```
 
 [npm]: https://www.npmjs.com/package/aws-cloudformation-custom-resource

--- a/test/lambda/index.ts
+++ b/test/lambda/index.ts
@@ -25,9 +25,15 @@ const region = 'us-east-1';
 const ssmClient = new SSMClient({ region });
 const logger = new StandardLogger(LogLevel.debug);
 
-export const handler = function (...lambdaArgs: [Event, Context, Callback]) {
+export const handler = function (
+  event: Event,
+  context: Context,
+  callback: Callback,
+) {
   new CustomResource(
-    ...lambdaArgs,
+    event,
+    context,
+    callback,
     createResource,
     updateResource,
     deleteResource,

--- a/test/lambda/index.ts
+++ b/test/lambda/index.ts
@@ -1,5 +1,5 @@
 // This test implementation manages an SSM parameter identified by the given `Name` property and returns the `ParameterVersion` as a response value.
-// Of course this does not make much sense, but it is a simple test case suits as an example of how to use the `aws-cloudformation-custom-resource` package to create a custom resource.
+// Of course this does not make much sense, but it is a simple test case and suits as an example of how to use the `aws-cloudformation-custom-resource` package to manage custom resources.
 import {
   DeleteParameterCommand,
   PutParameterCommand,
@@ -25,24 +25,22 @@ const region = 'us-east-1';
 const ssmClient = new SSMClient({ region });
 const logger = new StandardLogger(LogLevel.debug);
 
-export const handler = function (
-  event: Event,
-  context: Context,
-  callback: Callback,
-) {
-  new CustomResource(context, callback, logger)
-    .onCreate(createResource)
-    .onUpdate(updateResource)
-    .onDelete(deleteResource)
-    .handle(event);
+export const handler = function (...lambdaArgs: [Event, Context, Callback]) {
+  new CustomResource(
+    ...lambdaArgs,
+    createResource,
+    updateResource,
+    deleteResource,
+    logger,
+  );
 };
 
-function createResource(event: Event): Promise<Event> {
+function createResource(resource: CustomResource): Promise<void> {
   return new Promise(function (resolve, reject) {
     const params: PutParameterCommandInput = {
       /* eslint-disable @typescript-eslint/naming-convention */
-      Name: event.ResourceProperties?.name,
-      Value: event.ResourceProperties?.value,
+      Name: resource.event.ResourceProperties?.name,
+      Value: resource.event.ResourceProperties?.value,
       Type: 'String',
       Overwrite: false,
       /* eslint-enable @typescript-eslint/naming-convention */
@@ -51,8 +49,8 @@ function createResource(event: Event): Promise<Event> {
     ssmClient
       .send(putParameterCommand)
       .then((data) => {
-        event.addResponseValue('ParameterVersion', data.Version!.toString());
-        resolve(event);
+        resource.addResponseValue('ParameterVersion', data.Version!.toString());
+        resolve();
       })
       .catch((error) => {
         reject(error);
@@ -60,12 +58,12 @@ function createResource(event: Event): Promise<Event> {
   });
 }
 
-function updateResource(event: Event): Promise<Event> {
+function updateResource(resource: CustomResource): Promise<void> {
   return new Promise(function (resolve, reject) {
     const params: PutParameterCommandInput = {
       /* eslint-disable @typescript-eslint/naming-convention */
-      Name: event.ResourceProperties?.name,
-      Value: event.ResourceProperties?.value,
+      Name: resource.event.ResourceProperties?.name,
+      Value: resource.event.ResourceProperties?.value,
       Type: 'String',
       Overwrite: true,
       /* eslint-enable @typescript-eslint/naming-convention */
@@ -74,8 +72,8 @@ function updateResource(event: Event): Promise<Event> {
     ssmClient
       .send(putParameterCommand)
       .then((data) => {
-        event.addResponseValue('ParameterVersion', data.Version!.toString());
-        resolve(event);
+        resource.addResponseValue('ParameterVersion', data.Version!.toString());
+        resolve();
       })
       .catch((error) => {
         reject(error);
@@ -83,17 +81,17 @@ function updateResource(event: Event): Promise<Event> {
   });
 }
 
-function deleteResource(event: Event): Promise<Event> {
+function deleteResource(resource: CustomResource): Promise<void> {
   return new Promise(function (resolve, reject) {
     const params: DeleteParameterCommandInput = {
       // eslint-disable-next-line @typescript-eslint/naming-convention
-      Name: event.ResourceProperties?.name,
+      Name: resource.event.ResourceProperties?.name,
     };
     const deleteParameterCommand = new DeleteParameterCommand(params);
     ssmClient
       .send(deleteParameterCommand)
       .then((_data) => {
-        resolve(event);
+        resolve();
       })
       .catch((error) => {
         reject(error);

--- a/test/lambda/index.ts
+++ b/test/lambda/index.ts
@@ -19,6 +19,7 @@ import type {
   Event,
   Callback,
   Context,
+  Logger,
 } from 'aws-cloudformation-custom-resource';
 
 const region = 'us-east-1';
@@ -41,7 +42,10 @@ export const handler = function (
   );
 };
 
-function createResource(resource: CustomResource): Promise<void> {
+function createResource(
+  resource: CustomResource,
+  logger: Logger,
+): Promise<void> {
   return new Promise(function (resolve, reject) {
     const params: PutParameterCommandInput = {
       /* eslint-disable @typescript-eslint/naming-convention */
@@ -55,6 +59,7 @@ function createResource(resource: CustomResource): Promise<void> {
     ssmClient
       .send(putParameterCommand)
       .then((data) => {
+        logger.log('Parameter created successfully.');
         resource.addResponseValue('ParameterVersion', data.Version!.toString());
         resolve();
       })
@@ -64,7 +69,10 @@ function createResource(resource: CustomResource): Promise<void> {
   });
 }
 
-function updateResource(resource: CustomResource): Promise<void> {
+function updateResource(
+  resource: CustomResource,
+  logger: Logger,
+): Promise<void> {
   return new Promise(function (resolve, reject) {
     const params: PutParameterCommandInput = {
       /* eslint-disable @typescript-eslint/naming-convention */
@@ -78,6 +86,7 @@ function updateResource(resource: CustomResource): Promise<void> {
     ssmClient
       .send(putParameterCommand)
       .then((data) => {
+        logger.log('Parameter updated successfully.');
         resource.addResponseValue('ParameterVersion', data.Version!.toString());
         resolve();
       })
@@ -87,7 +96,10 @@ function updateResource(resource: CustomResource): Promise<void> {
   });
 }
 
-function deleteResource(resource: CustomResource): Promise<void> {
+function deleteResource(
+  resource: CustomResource,
+  logger: Logger,
+): Promise<void> {
   return new Promise(function (resolve, reject) {
     const params: DeleteParameterCommandInput = {
       // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -97,6 +109,7 @@ function deleteResource(resource: CustomResource): Promise<void> {
     ssmClient
       .send(deleteParameterCommand)
       .then((_data) => {
+        logger.log('Parameter deleted successfully.');
         resolve();
       })
       .catch((error) => {


### PR DESCRIPTION
A complete rewrite of the API, as it did not make too much sense the way it was.

1. Method chaining with `onCreate`, `onUpdate` and `onDelete` was cute but uselsss. Every resource handler requries methods for each action, so they should be required properties of the CustomResource class. 

   This also means, it is no longer possible to register multiple functions for each action, which also was an unneccessary feature. Instead the user could and should handle the logic within the respective function.

2. Instead of passing the Lambda event object through the functions (and abuse it as an envelope object) we now pass the custom resource object itself. This object now holds the Lambdas event, context and callback objects plus the logging object as properties, exposing all possibly required functionality to the user.

   Additional, the internally used logger object now is passed as 2nd paramter to the handler functions.

Previos usage:

```typescript
export const handler = function (
  event: Event,
  context: Context,
  callback: Callback,
) {
  new CustomResource(context, callback)
    .onCreate(createResource)
    .onUpdate(updateResource)
    .onDelete(deleteResource)
    .handle(event);
};

function createResource(event: Event): Promise<Event> {
  return new Promise(function (resolve, reject) {
    event.setPhysicalResourceId('some-physical-resource-id');

    event.addResponseValue('Foo', 'bar');

    // do stuff
    resolve(event);
  });
}
```

New usage:

```typescript
export const handler = function (
  event: Event,
  context: Context,
  callback: Callback,
) {
  new CustomResource(
    event,
    context,
    callback,
    createResource,
    updateResource,
    deleteResource,
  );
};

function createResource(
  resource: CustomResource,
  logger: Logger,
): Promise<void> {
  return new Promise(function (resolve, reject) {
    logger.log('Hello from create');

    resource.setPhysicalResourceId('some-physical-resource-id');

    resource.addResponseValue('Foo', 'bar');

    // do stuff
    resolve();
  });
}
```